### PR TITLE
Option to show daily price change in %

### DIFF
--- a/Another.Plasma6.Stock.Market/contents/config/main.xml
+++ b/Another.Plasma6.Stock.Market/contents/config/main.xml
@@ -42,6 +42,9 @@
     <entry name="apiKey" type="string">
       <default></default>
     </entry>
+    <entry name="tickerValue" type="string">
+      <default>current_price</default>
+    </entry>
   </group>
 
 </kcfg>

--- a/Another.Plasma6.Stock.Market/contents/ui/CompactRepresentation.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/CompactRepresentation.qml
@@ -73,6 +73,9 @@ ColumnLayout {
             getApi.tickerName = Plasmoid.configuration.tickerName;
             getApi.updatePrice();
         }
+        onTickerValueChanged: {
+            getApi.updatePrice();
+        }
     }
 
     // Determine which price text should be shown with multiplier applied
@@ -80,11 +83,18 @@ ColumnLayout {
         if (getApi.price === "E") {
             return "Err";
         }
-        if (getApi.price !== null && !isNaN(getApi.price)) {
-            // Apply price multiplier from configuration
-            var price = parseFloat(getApi.price);
-            var multiplier = Plasmoid.configuration.priceMultiplier || 1; // Default to 1 if multiplier is not set
-            return formatPrice((price * multiplier).toFixed(Plasmoid.configuration.decimalPlaces));
+        console.log("Ticker Value:", Plasmoid.configuration.tickerValue);
+        if (Plasmoid.configuration.tickerValue === "daily_price_change_percantage") {
+            if (getApi.daily_price_change_percantage !== null && !isNaN(getApi.daily_price_change_percantage)) {
+                return getApi.daily_price_change_percantage.toFixed(Plasmoid.configuration.decimalPlaces) + "%";
+            }
+        } else {
+            if (getApi.price !== null && !isNaN(getApi.price)) {
+                // Apply price multiplier from configuration
+                var price = parseFloat(getApi.price);
+                var multiplier = Plasmoid.configuration.priceMultiplier || 1;
+                return formatPrice((price * multiplier).toFixed(Plasmoid.configuration.decimalPlaces));
+            }
         }
         return "?";
     }
@@ -102,7 +112,7 @@ ColumnLayout {
         }
         font.bold: Plasmoid.configuration.textBold
         font.capitalization: Font.AllUppercase
-        text: (Plasmoid.configuration.tickerName || "Unknown ticker") + (Plasmoid.configuration.priceMultiplier !== "1" && Plasmoid.configuration.priceMultiplier !== "" ? "*" : "")
+        text: (Plasmoid.configuration.tickerName || "Unknown ticker") + (Plasmoid.configuration.priceMultiplier !== "1" && Plasmoid.configuration.priceMultiplier !== "" && Plasmoid.configuration.tickerValue !== "daily_price_change_percantage" ? "*" : "")
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignTop
     }
@@ -114,6 +124,13 @@ ColumnLayout {
         color: {
             if (displayedPrice === "Err") {
                 return Plasmoid.configuration.errorColor || Kirigami.Theme.negativeTextColor;
+            }
+            if (Plasmoid.configuration.tickerValue === "daily_price_change_percantage") {
+                if (getApi.daily_price_change_percantage > 0) {
+                    return Kirigami.Theme.positiveTextColor;
+                } else if (getApi.daily_price_change_percantage < 0) {
+                    return Kirigami.Theme.negativeTextColor;
+                }
             }
             return Plasmoid.configuration.textColor || Kirigami.Theme.textColor;
         }

--- a/Another.Plasma6.Stock.Market/contents/ui/CompactRepresentation.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/CompactRepresentation.qml
@@ -53,6 +53,21 @@ ColumnLayout {
         return formattedPrice;
     }
 
+    function formatPriceChange(priceChange) {
+        let numChange = parseFloat(priceChange);
+        if (isNaN(numChange)) {
+            return priceChange;
+        }
+
+        let formattedChange = formatPrice(numChange.toFixed(Plasmoid.configuration.decimalPlaces));
+
+        if (numChange >= 0) {
+            formattedChange = "+" + formattedChange;
+        }
+
+        return formattedChange + "%";
+    }
+
     Layout.minimumWidth: tickerText.implicitWidth + pixelFontVar * 4
     Layout.minimumHeight: heightroot
 
@@ -83,20 +98,21 @@ ColumnLayout {
         if (getApi.price === "E") {
             return "Err";
         }
-        console.log("Ticker Value:", Plasmoid.configuration.tickerValue);
-        if (Plasmoid.configuration.tickerValue === "daily_price_change_percantage") {
-            if (getApi.daily_price_change_percantage !== null && !isNaN(getApi.daily_price_change_percantage)) {
-                return getApi.daily_price_change_percantage.toFixed(Plasmoid.configuration.decimalPlaces) + "%";
-            }
-        } else {
-            if (getApi.price !== null && !isNaN(getApi.price)) {
-                // Apply price multiplier from configuration
-                var price = parseFloat(getApi.price);
-                var multiplier = Plasmoid.configuration.priceMultiplier || 1;
-                return formatPrice((price * multiplier).toFixed(Plasmoid.configuration.decimalPlaces));
-            }
+
+        var multiplier = Plasmoid.configuration.priceMultiplier || 1;
+        switch (Plasmoid.configuration.tickerValue) {
+            case "daily_price_change_percentage":
+                var priceChange = parseFloat(getApi.dailyPriceChangePercentage);
+                return formatPriceChange(priceChange * multiplier);
+            case "current_price":
+                if (getApi.price !== null && !isNaN(getApi.price)) {
+                    var price = parseFloat(getApi.price);
+                    return formatPrice((price * multiplier).toFixed(Plasmoid.configuration.decimalPlaces));
+                }
+                return "?";
+            default:
+                return "Err";
         }
-        return "?";
     }
 
     Text {
@@ -112,7 +128,7 @@ ColumnLayout {
         }
         font.bold: Plasmoid.configuration.textBold
         font.capitalization: Font.AllUppercase
-        text: (Plasmoid.configuration.tickerName || "Unknown ticker") + (Plasmoid.configuration.priceMultiplier !== "1" && Plasmoid.configuration.priceMultiplier !== "" && Plasmoid.configuration.tickerValue !== "daily_price_change_percantage" ? "*" : "")
+        text: (Plasmoid.configuration.tickerName || "Unknown ticker") + (Plasmoid.configuration.priceMultiplier !== "1" && Plasmoid.configuration.priceMultiplier !== "" ? "*" : "")
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignTop
     }
@@ -125,10 +141,10 @@ ColumnLayout {
             if (displayedPrice === "Err") {
                 return Plasmoid.configuration.errorColor || Kirigami.Theme.negativeTextColor;
             }
-            if (Plasmoid.configuration.tickerValue === "daily_price_change_percantage") {
-                if (getApi.daily_price_change_percantage > 0) {
+            if (Plasmoid.configuration.tickerValue === "daily_price_change_percentage") {
+                if (getApi.dailyPriceChangePercentage > 0) {
                     return Kirigami.Theme.positiveTextColor;
-                } else if (getApi.daily_price_change_percantage < 0) {
+                } else if (getApi.dailyPriceChangePercentage < 0) {
                     return Kirigami.Theme.negativeTextColor;
                 }
             }

--- a/Another.Plasma6.Stock.Market/contents/ui/GeneralConfig.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/GeneralConfig.qml
@@ -9,6 +9,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts 1.11
 import org.kde.kirigami as Kirigami
+import "./components" as Components
 
 Item {
     id: configRoot
@@ -108,6 +109,25 @@ Item {
                 }
                     ToolTip.visible: hovered
                     ToolTip.text: i18n("USA Stock Market Ticker, like MSTR, AAPL, AMZN, GE, or SPY. Only uppercase letters and dots are allowed.")
+                }
+
+                // Ticker Value
+                Label {
+                    Layout.minimumWidth: root.width / 2
+                    text: i18n("Ticker Value:")
+                    horizontalAlignment: Label.AlignRight
+                }
+                Components.ConfigComboBox {
+                    cfg_key: "tickerValue"
+                    cfg_defaultValue: "current_price"
+                    model: [
+                        { text: i18n("Current Price"), value: "current_price" },
+                        { text: i18n("Daily Price Change (%)"), value: "daily_price_change_percantage" }
+                    ]
+                    onCurrentValueChanged: {
+                        plasmoid.configuration.tickerValue = currentValue;
+                        configurationChanged();
+                    }
                 }
 
                 // Show Ticker Name

--- a/Another.Plasma6.Stock.Market/contents/ui/GeneralConfig.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/GeneralConfig.qml
@@ -122,7 +122,7 @@ Item {
                     cfg_defaultValue: "current_price"
                     model: [
                         { text: i18n("Current Price"), value: "current_price" },
-                        { text: i18n("Daily Price Change (%)"), value: "daily_price_change_percantage" }
+                        { text: i18n("Daily Price Change (%)"), value: "daily_price_change_percentage" }
                     ]
                     onCurrentValueChanged: {
                         plasmoid.configuration.tickerValue = currentValue;

--- a/Another.Plasma6.Stock.Market/contents/ui/components/ConfigComboBox.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/components/ConfigComboBox.qml
@@ -1,0 +1,29 @@
+import QtQuick
+import QtQuick.Controls
+
+ComboBox {
+    id: control
+
+    signal valueChanged
+
+    property string cfg_key
+    property var cfg_defaultValue
+
+    textRole: "text"
+    valueRole: "value"
+
+    Component.onCompleted: {
+        if (cfg_key) {
+            var value = Plasmoid.configuration[cfg_key]
+            if (value === undefined) {
+                value = cfg_defaultValue
+            }
+            for (var i = 0; i < model.length; i++) {
+                if (model[i].value === value) {
+                    currentIndex = i
+                    break
+                }
+            }
+        }
+    }
+}

--- a/Another.Plasma6.Stock.Market/contents/ui/components/GetAPI.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/components/GetAPI.qml
@@ -13,7 +13,7 @@ Item {
     property int decimalPlaces: 2
     property int refreshRate: Plasmoid.configuration.timeRefresh || 3 // Refresh rate in minutes, linked to config
     property var price: null // Set no initial price
-    property var daily_price_change_percantage: null
+    property var dailyPriceChangePercentage: null
     property bool inErrorState: false
 
     onTickerNameChanged: updatePrice()
@@ -39,7 +39,7 @@ Item {
                     const data = JSON.parse(req.responseText);
                     if (data && data.c && data.dp) {
                         price = parseFloat(data.c); // Parse and store the price
-                        daily_price_change_percantage = parseFloat(data.dp);
+                        dailyPriceChangePercentage = parseFloat(data.dp);
                         inErrorState = false;
                     } else {
                         // If no valid price data, set as error state

--- a/Another.Plasma6.Stock.Market/contents/ui/components/GetAPI.qml
+++ b/Another.Plasma6.Stock.Market/contents/ui/components/GetAPI.qml
@@ -13,6 +13,7 @@ Item {
     property int decimalPlaces: 2
     property int refreshRate: Plasmoid.configuration.timeRefresh || 3 // Refresh rate in minutes, linked to config
     property var price: null // Set no initial price
+    property var daily_price_change_percantage: null
     property bool inErrorState: false
 
     onTickerNameChanged: updatePrice()
@@ -36,8 +37,9 @@ Item {
             if (req.status === 200) {
                 try {
                     const data = JSON.parse(req.responseText);
-                    if (data && data.c) {
+                    if (data && data.c && data.dp) {
                         price = parseFloat(data.c); // Parse and store the price
+                        daily_price_change_percantage = parseFloat(data.dp);
                         inErrorState = false;
                     } else {
                         // If no valid price data, set as error state


### PR DESCRIPTION
closes #1 

This PR adds a configuration option:

<img width="623" height="423" alt="image" src="https://github.com/user-attachments/assets/3d60baec-83fe-4ab2-8507-e52c2820b775" />

which makes the component show the daily change in % instead of the raw price:

<img width="137" height="93" alt="image" src="https://github.com/user-attachments/assets/c97e040a-6fca-49d3-9027-7ae4dc1786aa" />

<img width="132" height="87" alt="image" src="https://github.com/user-attachments/assets/d72e572a-6f13-4dd2-9068-e3d4558cb5c5" />

- [X] Works with the multiplier
- [X] Works with the Thousands Separator
- [X] Works with Swap commas-dots

i used `Kirigami.Theme.positiveTextColor` and `Kirigami.Theme.negativeTextColor`
to style the text.

For some reason the value mode updates instantly when the combobox is changed (so pressing apply is not required).
Im new to qml and i have no idea how to fix this.